### PR TITLE
Adding missing end brace in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,4 +17,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/JohnMcLear/ep_font_family.git"
+  }
 }


### PR DESCRIPTION
This was breaking `npm install` from url.